### PR TITLE
Feature/biocadmin improved debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 cache: pip
 install: pip install pyflakes
 script:
-  - shellcheck ./3.3/bioc/zin2/postrun.sh  ./3.2/bioc/zin1/postrun.sh
+  - shellcheck ./3.3/bioc/zin2/postrun.sh  ./3.2/bioc/zin1/postrun.sh ./manage-BioC-repos/common/biocadmin-build-steps.sh ./utils/bashErrorHandler.sh
   - pyflakes *.py
   - python -c 'print "Finished static analysis"'
 notifications:

--- a/manage-BioC-repos/common/biocadmin-build-steps.sh
+++ b/manage-BioC-repos/common/biocadmin-build-steps.sh
@@ -25,8 +25,7 @@ fi
 
 source "$grandparent_dir""${version_to_build}"/config.sh
 
-# The steps executed by 'biocadmin' will not
-# succeed without the following :
+# TODO: Determine preconditions for biocadmin's cron to run.  Modify below accordingly
 biocadmin_precondition=true
 if ! [ $biocadmin_precondition ]; then
   err_msg="Preconditions for build steps are not met (for biocadmin).  Can not continue."

--- a/manage-BioC-repos/common/biocadmin-build-steps.sh
+++ b/manage-BioC-repos/common/biocadmin-build-steps.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Declare all local vars
+local me grandparent_dir err_msg log_file
+
+# The current script's name
+me=$(basename "$0")
+
+# Adapted from : http://stackoverflow.com/a/246128/320399
+grandparent_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd ../.. && pwd )
+
+# Provides the function `bashErrorHandler`
+source "${grandparent_dir}"/utils/bashErrorHandler.sh
+trap 'bashErrorHandler ${me} ${LINENO}' ERR
+
+if [ "$(whoami)" != "biocadmin" ]; then
+  bashErrorHandler "$me" "$LINENO" "This script must be run as user 'biocadmin'.  Can not continue"
+fi
+
+if [ -z "$1" ]; then
+  bashErrorHandler "$me" "$LINENO" "Version to build is empty.  Can not continue."
+else
+  local version_to_build=$1
+fi
+
+source "$grandparent_dir""${version_to_build}"/config.sh
+
+# The steps executed by 'biocadmin' will not
+# succeed without the following :
+biocadmin_precondition=true
+if ! [ $biocadmin_precondition ]; then
+  err_msg="Preconditions for build steps are not met (for biocadmin).  Can not continue."
+  bashErrorHandler "$me" "$LINENO" "$err_msg"
+fi
+
+log_file=/home/biocadmin/cron.log/"$BBS_BIOC_VERSION"/updateRepos-bioc.log
+
+cd manage-BioC-repos/"$version_to_build" || bashErrorHandler "$me" "$LINENO" "An error occurred attempting to cd to manage-BioC-repos/$version_to_build . Cannot continue"
+
+# Group the following commands and redirect all
+# output to the same log.
+# TODO: Consider splitting logs to separate files
+#	and handling STDOUT / STDERR distinctly
+{
+  ./updateReposPkgs-bioc.sh
+  ./prepareRepos-bioc.sh
+  ./pushRepos-bioc.sh
+} >> "$log_file" 2>&1

--- a/utils/bashErrorHandler.sh
+++ b/utils/bashErrorHandler.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# TODO: Once the build system is better understood, we should uncomment the exit at the
+#   end of this function and 'fail fast' with confidence.  However, for now, it'll be
+#   safer to print output that indicates something seems like an error as a notice that it
+#   should be ispected.  Something that seems like an error may actualy be an expected
+#   state, which we won't want to break by detecting a false positive.
+
+# Adapted from http://stackoverflow.com/a/185900/320399
+bashErrorHandler() {
+  echo "EEE - Start of bashErrHandler" >&2
+  if [ "$#" -ne 4 ]; then
+    echo "Detected incorrect number of arguments.  Output may be incorrect." >&2
+  fi
+
+  # Declare all local variables
+  local parent_script parent_lineno errloc message code email_subject
+
+  # Error location
+  parent_script="${1:-UNKNOWN}"
+  parent_lineno="${2:-UNKNOWN}"
+  errloc="$parent_script:$parent_lineno"
+  # Optionally provide an error message
+  message="${3:-Unknown Error}"
+  # Error code is -1 by default
+  code="${4:-1}" 
+  
+  err_msg="Error on or near '${errloc}'; ${message}; exiting with status ${code}" >&2
+  
+  # Print the message to STDERR  
+  echo "$err_msg" >&2
+  email_subject="BBS error encountered by '$(whoami)'"
+  # Send the message to an email recipient
+  echo "$err_msg" | mail -s "$email_subject" brian@bioconductor.org
+
+  echo "EEE - End of bashErrHandler" >&2
+  # TODO: See note at start of function
+  # exit "${code}"
+}


### PR DESCRIPTION
@vobencha or @jimhester Mind taking a look at this if you have a moment?  I don't need this merged yet, I'm just looking for feedback.  

Goals I'm trying to work towards are : 
- Be deterministic
- Fail fast
- Separating `STDERR` and `STDOUT`
- Dynamically determining paths rather than hardcoding

This PR works towards a fix for https://github.com/Bioconductor/BBS/issues/14 and https://github.com/Bioconductor/BBS/issues/18

The basic idea is to replace the crontab from biocadmin (@ zin1 and zin2), with something that will help us understand errors (or what seems like errors) in the build system.  We're not exactly _failing fast_, but we're capturing the places where there may be a problem and logging them (as well as emailing me).  

The crontab entry that this could be swapped for is : 
```
45 11 * * * cd /home/biocadmin/manage-BioC-repos/3.3 && (./updateReposPkgs-bioc.sh && ./prepareRepos-bioc.sh && ./pushRepos-bioc.sh) >>/home/biocadmin/cron.log/3.3/prepareRepos-bioc.log 2>&1
```
The new entry would be : 
```
45 11 * * * /home/biocadmin/manage-BioC-repos/common/biocadmin-build-steps.sh 3.3
```

#### Obvious changes that need to be made 
1.  The value of `biocadmin_precondition` in `manage-BioC-repos/common/biocadmin-build-steps.sh` should be determined in a reasonable way, based on the phases of the build that should have completed by the time this script runs.  My strategy for that is simply to have the known step before this (`biocbuild`'s `BBS/3.3/bioc/zin2/postrun.sh` write a file that serves as a marker and check for the marker ).  The file could be named according to the current date, and the previous date's file cleaned up at the completion of a new day's build.  If the marker isn't present, `bashErrorHandler` will write to the error log and send me an email notifying me of the problem.

2.  Rather than passing the current build version as an argument in the `crontab`, the script can source [`bioc-cm`](https://travis-ci.org/Bioconductor/bioc-cm) and use it's hostname to determine it's role.  I'm holding off on making that change until we determine which user should own (_git clone ..._) such a resource.  Right now, `biocbuild` and `biocadmin` each have a copy of the same code (BBS) on the same server.  Rather than follow that example, I think we only need one copy of each repository on a build server.  However, neither of those user's are probably appropriate to own `bioc-cm`, since it can (and probably should) be extended to include other environment information.