### PR TITLE
Fix bug (stage 4 not executed).

### DIFF
--- a/BBS-run.py
+++ b/BBS-run.py
@@ -456,6 +456,8 @@ def STAGE4_loop(srcpkg_paths, nb_cpu):
     nb_jobs = len(job_queue)
     print "BBS> BEGIN STAGE4 loop."
     t0 = time.time()
+    bbs.jobs.processJobQueue(job_queue, None, nb_cpu,
+                                           BBScorevars.r_cmd_timeout, True)
     dt = time.time() - t0
     print "BBS> END STAGE4 loop."
     print "BBS> -------------------------------------------------------------"
@@ -592,4 +594,3 @@ if __name__ == "__main__":
 # 01/24/2006: 642 lines in BBSbase.py + 286 lines in BBS-run.py
 # 08/17/2006: 772 lines in BBSbase.py + 147 lines in BBSvars.py + 355 lines in BBS-run.py
 # 01/12/2007: 777 lines in BBSbase.py + 130 in BBSvars.py + 225 in BBS-prerun.py + 357 in BBS-run.py
-


### PR DESCRIPTION
This bug was introduced by the following commit : https://github.com/Bioconductor/BBS/commit/13c3d5ca0fc6462f49d367878b8464b706427b92

Since `nb_products` is not logged in stage 4 (it is in stage 3 and 5), it was
flagged for removal by pyflakes (our static analysis tool).

cc/ @hpages @jimhester @mtmorgan 