### PR TITLE
Changes to support running SPB locally

### DIFF
--- a/BBScorevars.py
+++ b/BBScorevars.py
@@ -8,9 +8,13 @@
 
 import sys
 import os
-
+import logging
 import bbs.rdir
+import platform
 
+logging.basicConfig(format='%(levelname)s: %(asctime)s %(filename)s - %(message)s',
+                    datefmt='%m/%d/%Y %I:%M:%S %p',
+                    level=logging.DEBUG)
 
 # TODO: Indent the output (use length of stack as the indent level)
 class Debug:
@@ -96,7 +100,21 @@ pkgType2FileExt = { \
 }
 
 def getNodeSpec(node_hostname, key):
-    spec = nodespecs.allnodes[node_hostname.lower()]
+    
+    spec = None
+    if node_hostname in nodespecs.allnodes: 
+        logging.info("Now attempting to get spec based on node_hostname '%s'", node_hostname)
+        spec = nodespecs.allnodes[node_hostname.lower()]
+    else:
+        logging.warn("node_hostname '%s' is not listed in the hardcoded dictionary.  "
+            "Will attempt to create `spec` object dynamically.")
+        logging.warn("All packages will be built from source with UTF-8 encoding")
+        spec = (platform.platform(), \
+                       platform.architecture(), \
+                       platform.architecture(), \
+                       "source", \
+                       "utf_8")
+    
     if key == 'OS':
         return spec[0]
     if key == 'Arch':
@@ -140,4 +158,3 @@ mode = getenv('BBS_MODE', False, "bioc")
 r_cmd_timeout = float(getenv('BBS_R_CMD_TIMEOUT', False, "2400.0"))
 
 meat_index_file = 'meat-index.txt'
-

--- a/BBScorevars.py
+++ b/BBScorevars.py
@@ -103,16 +103,16 @@ def getNodeSpec(node_hostname, key):
     
     spec = None
     if node_hostname in nodespecs.allnodes: 
-        logging.info("Now attempting to get spec based on node_hostname '%s'", node_hostname)
+        logging.info("Now attempting to get spec based on node_hostname '{hostname}'".format(hostname = node_hostname))
         spec = nodespecs.allnodes[node_hostname.lower()]
     else:
-        logging.warn("node_hostname '%s' is not listed in the hardcoded dictionary.  "
-            "Will attempt to create `spec` object dynamically.")
+        logging.warn("node_hostname '{hostname}' is not listed in the hardcoded dictionary.  "
+            "Will attempt to create `spec` object dynamically.".format(hostname = node_hostname))
         logging.warn("All packages will be built from source with UTF-8 encoding")
-        spec = (platform.platform(), \
-                       platform.architecture(), \
-                       platform.architecture(), \
-                       "source", \
+        spec = (platform.platform(),
+                       platform.architecture(),
+                       platform.architecture(),
+                       "source",
                        "utf_8")
     
     if key == 'OS':


### PR DESCRIPTION
This work should be merged soon (or at least addressed and some solution decided).  This has to do with the following issues.  Note, they exist in separate Git repositories :
- https://github.com/Bioconductor/BBS/issues/38
- https://github.com/Bioconductor/packagebuilder/pull/18

In the SPB, there are 8 invocations of `getNodeSpec` in `builder.py`.  Here are some : 
- https://github.com/Bioconductor/packagebuilder/blob/master/workers/builder.py#L179
- https://github.com/Bioconductor/packagebuilder/blob/master/workers/builder.py#L596
- https://github.com/Bioconductor/packagebuilder/blob/master/workers/builder.py#L717

The issue is that we need a module created that is separate from BBS and SPB, which provides the common functionality.  Currently, the SPB changes it's module loading path (both in the [master branch](https://github.com/Bioconductor/packagebuilder/blob/master/workers/builder.py#L230-L235), and [my pending PR](https://github.com/b-long/packagebuilder/blob/feature/fault-tolerance/workers/builder.py#L27-L32)).  As far as I can tell, this is a big anti-pattern.  Instead, we should use a package maintenance strategy / tool.  One strategy might be enumerating the dependencies explicitly (`pip freeze`) and installing the dependencies them before installing BBS / SPB : 
```
# Future BBS / SPB install example :
git clone git@github.com:Bioconductor/packagebuilder.git # Or BBS
cd packagebuilder
# Create or activate virtual environment
pip install git+ssh://git@github.com/Bioconductor/bioc-common-python.git
pip install -r spb-requirements.txt
```

Please feel free to give feedback, as I'm less familiar with Python
cc/ @dtenenba @jimhester 