### PR TITLE
Move apt and pip dependencies to Ubuntu-files

### DIFF
--- a/Doc/Prepare-Ubuntu-20.04-HOWTO.md
+++ b/Doc/Prepare-Ubuntu-20.04-HOWTO.md
@@ -382,78 +382,39 @@ environment. For now `echo $DISPLAY` should show nothing.
 
 ### 1.8 Install Ubuntu/deb packages
 
-Install with:
+The packages for setting up the build system are in `BBS/Ubuntu-files/20.04`.
+They should be installed with
 
     sudo apt-get install <pkg1> <pkg2> <pkg3> ...
 
+They can also be installed with the following code where `BBS_UBUNTU_PATH`
+is the path to `BBS/Ubuntu-files/20.04` and `BBS_PACKAGES_FILE` is the
+name of the text file containing the list of packages:
+
+    BBS_UBUNTU_PATH=
+    BBS_PACKAGES_FILE=
+    sudo apt install $(cat $BBS_UBUNTU_PATH/$BBS_PACKAGES_FILE | awk '/^[^#]/ {print $1}')
+
+
 #### Always nice to have
 
-    sudo apt-get install tree manpages-dev mlocate
-
-Notes:
-- `manpages-dev` provides the man pages for the C standard lib
-- `mlocate` provides the 'locate' command
+[apt_nice_to_have.txt](../Ubuntu-files/20.04/apt_nice_to_have.txt)
 
 #### Packages required by the build system itself (BBS)
 
-    sudo apt-get install python3-minimal python3-pip git
+[apt_required_build.txt](../Ubuntu-files/20.04/apt_required_build.txt)
 
-#### Packages required to compile R
+#### Packages for compiling R
 
-Strictly required:
+[apt_required_compile_R.txt](../Ubuntu-files/20.04/apt_required_compile_R.txt) are
+required to compile R.
 
-    sudo apt-get install build-essential \
-                         gfortran \
-                         libreadline-dev \
-                         libx11-dev \
-                         libxt-dev \
-                         zlib1g-dev \
-                         libbz2-dev \
-                         liblzma-dev \
-                         libpcre2-dev \
-                         libcurl4-openssl-dev
-
-Optional (still possible to compile R without these packages but some
-capabilities will be missing):
-
-    sudo apt-get install gobjc \
-                         libpng-dev \
-                         libjpeg-dev \
-                         libtiff-dev \
-                         libcairo2-dev \
-                         libicu-dev \
-                         tcl-dev \
-                         tk-dev \
-                         default-jdk
+[apt_optional_compile_R.txt](../Ubuntu-files/20.04/apt_optional_compile_R.txt)
+are optional;  however, some capabilities will be missing.
 
 #### Packages needed to build vignettes and reference manuals
 
-    sudo apt-get install texlive \
-                         texlive-font-utils \
-                         texlive-pstricks \
-                         texlive-latex-extra \
-                         texlive-fonts-extra \
-                         texlive-bibtex-extra \
-                         texlive-science \
-                         texlive-luatex \
-                         texlive-lang-european \
-                         texi2html \
-                         texinfo \
-                         pandoc \
-                         pandoc-citeproc \
-                         biber
-                         #ttf-mscorefonts-installer
-
-Notes:
-- `texlive-font-utils` is for epstopdf.
-- `texlive-pstricks` provides `pstricks.sty`.
-- `texlive-latex-extra` provides `fullpage.sty`.
-- `texlive-fonts-extra` provides `incosolata.sty`.
-- `texlive-bibtex-extra` provides `unsrturl.bst`.
-- `texlive-science` provides `algorithm.sty`.
-- `texlive-luatex` provides `luatex85.sty`.
-- `texlive-lang-european` provides language definition files e.g. `swedish.ldf`.
-- `pandoc` and `pandoc-citeproc` are needed by CRAN package knitr.
+[apt_vignettes_reference_manuals.txt](../Ubuntu-files/20.04/apt_vignettes_reference_manuals.txt)
 
 #### Packages needed to support extra fonts (e.g. Helvetica)
 
@@ -462,98 +423,19 @@ Some R code can fail with errors like:
     Error in grid.Call(C_stringMetric, as.graphicsAnnot(x$label)) :
       X11 font -adobe-helvetica-%s-%s-*-*-%d-*-*-*-*-*-*-*, face 1 at size 11 could not be loaded
 
-This can be solved by installing the following packages:
-
-    sudo apt-get install gsfonts-x11 \
-                         xfonts-base \
-                         xfonts-scalable \
-                         xfonts-100dpi \
-                         xfonts-75dpi \
-                         t1-xfree86-nonfree \
-                         ttf-xfree86-nonfree \
-                         ttf-xfree86-nonfree-syriac
+This can be solved by installing the packages in
+[apt_extra_fonts.txt](../Ubuntu-files/20.04/apt_extra_fonts.txt)
 
 Note that a reboot is required to make the fix effective.
 
 #### Packages needed by some CRAN and/or BioC packages
 
-For CRAN packages:
-
-    sudo apt-get install libglu1-mesa-dev \
-                         librsvg2-dev \
-                         libgmp-dev \
-                         libssl-dev \
-                         libsasl2-dev \
-                         libxml2-dev \
-                         libcurl4-openssl-dev \
-                         mpi-default-dev \
-                         libudunits2-dev \
-                         libv8-dev \
-                         libmpfr-dev \
-                         libfftw3-dev \
-                         libmysqlclient-dev \
-                         libpq-dev \
-                         libmagick++-dev \
-                         libgeos-dev \
-                         libproj-dev \
-                         libgdal-dev \
-                         libpoppler-cpp-dev \
-                         libgtk2.0-dev \
-                         libgit2-dev \
-                         jags \
-                         libprotobuf-dev \
-                         protobuf-compiler \
-                         libglpk-dev
+For CRAN packages, install [apt_cran.txt](../Ubuntu-files/20.04/apt_cran.txt).
 
 Notes:
 - Do NOT install `cwltool` (for Rcwl)! Install with `pip3` instead (see below).
-- `libglu1-mesa-dev` is for rgl.
-- `librsvg2-dev` is for rsvg.
-- `libgmp-dev` is for gmp.
-- `libssl-dev` is for openssl and mongolite.
-- `libsasl2-dev` is for mongolite.
-- `libxml2-dev` is for XML.
-- `libcurl4-openssl-dev` is for RCurl and curl.
-- `mpi-default-dev` is for Rmpi.
-- `libudunits2-dev` is for units.
-- `libv8-dev` is for V8.
-- `libmpfr-dev` is for Rmpfr.
-- `libfftw3-dev` is for fftw and fftwtools.
-- `libmysqlclient-dev` is for RMySQL.
-- `libpq-dev` is for RPostgreSQL and RPostgres.
-- `libmagick++-dev` is for magick.
-- `libgeos-dev` is for rgeos.
-- `libproj-dev` is for proj4.
-- `libgdal-dev` is for sf.
-- `libpoppler-cpp-dev` is for pdftools.
-- `libgtk2.0-dev` is for RGtk2.
-- `libgit2-dev` is for gert.
-- `jags` is for rjags.
-- `libprotobuf-dev` and `protobuf-compiler` are for protolite.
-- `libglpk-dev` is for glpkAPI and to compile igraph with GLPK support.
 
-For BioC packages:
-
-    sudo apt-get install firefox \
-                         graphviz \
-                         libgraphviz-dev \
-                         libgtkmm-2.4-dev \
-                         libgsl-dev \
-                         libsbml5-dev \
-                         automake \
-                         libnetcdf-dev \
-                         libopenbabel-dev \
-                         libeigen3-dev \
-                         clustalo \
-                         ocl-icd-opencl-dev \
-                         libavfilter-dev \
-                         libfribidi-dev \
-                         infernal \
-                         fuse \
-                         libfuse-dev \
-                         kallisto \
-                         mono-runtime \
-                         libmono-system-data4.0-cil
+For BioC packages, install [apt_bioc.txt](../Ubuntu-files/20.04/apt_bioc.txt).
 
 Notes:
 - `firefox` (or any other web browser) is needed by many Bioconductor
@@ -563,23 +445,8 @@ Notes:
   pass `R CMD build` and `R CMD check` if no browser is to be found on
   the system, with the exception of BrowserViz whose unit tests will
   timeout in that case.
-- `graphviz` and `libgraphviz-dev` are for Rgraphviz.
-- `libgtkmm-2.4-dev` is for HilbertVisGUI.
-- `libgsl-dev` is for all the packages that depend on the GSL.
-- `libsbml5-dev` is for rsbml.
-- `automake` is for RProtoBufLib.
-- `libnetcdf-dev` is for mzR, RNetCDF, etc...
-- `libopenbabel-dev` and `libeigen3-dev` are for ChemmineOB.
-- `clustalo` is for LowMACA.
-- `ocl-icd-opencl-dev` is for gpuMagic.
-- `libavfilter-dev` is for av/spatialHeatmap.
 - `libfribidi-dev` is for CRAN package textshaping which BioC package
   EnhancedVolcano indirectly depends on via ragg and ggrastr.
-- `infernal` is for inferrnal.
-- `fuse` and `libfuse-dev` are for Travel.
-- `kallisto` is for rkal.
-- `mono-runtime` and `libmono-system-data4.0-cil` are for rawrr.
-
 
 ### 1.9 Install Python 3 modules
 
@@ -588,7 +455,7 @@ Notes:
 `virtualenv` is used by the Single Package Builder. Despite python3 shipping
 with `venv`, `venv` is not sufficient. The SPB must use `virtualenv`.
 
-    sudo -H pip3 install virtualenv
+    sudo -H pip3 install -r $BBS_UBUNTU_PATH/pip_spb.txt
 
 #### Python 3 modules needed by some CRAN/Bioconductor packages
 
@@ -600,12 +467,7 @@ biocbuild for BBS or pkgbuild for the Single Package Builder). Since we
 only install _trusted_ modules, this should not be a security concern. See
 https://askubuntu.com/questions/802544/is-sudo-pip-install-still-a-broken-practice)
 
-    sudo -H pip3 install numpy scipy sklearn h5py pandas mofapy mofapy2
-    sudo -H pip3 install testresources tensorflow tensorflow_probability
-    sudo -H pip3 install h5pyd
-    sudo -H pip3 install cwltool
-    sudo -H pip3 install nbconvert jupyter
-    sudo -H pip3 install matplotlib phate
+    sudo -H pip3 install -r $BBS_UBUNTU_PATH/pip_pkgs.txt
 
 Notes:
 

--- a/Ubuntu-files/20.04/apt_bioc.txt
+++ b/Ubuntu-files/20.04/apt_bioc.txt
@@ -1,0 +1,21 @@
+# APT packages needed for BioC packages
+firefox                     # for packages using utils::browseURL()
+graphviz                    # for Rgraphviz
+libgraphviz-dev             # for Rgraphviz
+libgtkmm-2.4-dev            # for HilbertVisGUI
+libgsl-dev                  # for GSL
+libsbml5-dev                # for rsbml
+automake                    # for RProtoBufLib
+libnetcdf-dev               # for mzR, RNetCDF
+libopenbabel-dev            # for ChemmineOB
+libeigen3-dev               # for ChemmineOB
+clustalo                    # for LowMACA
+ocl-icd-opencl-dev          # for gpuMagic
+libavfilter-dev             # for av/spacialHeatmap
+libfribidi-dev              # for EnhancedVolcano
+infernal                    # for inferrnal
+fuse                        # for Travel
+libfuse-dev                 # for Travel
+kallisto                    # for rkal
+mono-runtime                # for rawr
+libmono-system-data4.0-cil  # for rawr

--- a/Ubuntu-files/20.04/apt_cran.txt
+++ b/Ubuntu-files/20.04/apt_cran.txt
@@ -1,0 +1,26 @@
+# APT packages needed for CRAN packages
+libglu1-mesa-dev        # for rgl
+librsvg2-dev            # for rsvg
+libgmp-dev              # for gmp
+libssl-dev              # for openssl, mongolite
+libsasl2-dev            # for mongolite
+libxml2-dev             # for XML
+libcurl4-openssl-dev    # for RCurl, curl
+mpi-default-dev         # for Rmpi
+libudunits2-dev         # for units
+libv8-dev               # for V8
+libmpfr-dev             # for Rmpfr
+libfftw3-dev            # for fftw, fftwtools
+libmysqlclient-dev      # for RMySQL
+libpq-dev               # for RPostgreSQL, RPostgres
+libmagick++-dev         # for magick
+libgeos-dev             # for rgeos
+libproj-dev             # for proj4
+libgdal-dev             # for sf
+libpoppler-cpp-dev      # for pdftools
+libgtk2.0-dev           # for RGtk2
+libgit2-dev             # for gert
+jags                    # for rjags
+libprotobuf-dev         # for protolite
+protobuf-compiler       # for protolite
+libglpk-dev             # for glpkAPI and to compile igraph with GLPK support

--- a/Ubuntu-files/20.04/apt_extra_fonts.txt
+++ b/Ubuntu-files/20.04/apt_extra_fonts.txt
@@ -1,0 +1,9 @@
+# APT packages for extra fonts
+gsfonts-x11
+xfonts-base
+xfonts-scalable
+xfonts-100dpi
+xfonts-75dpi
+t1-xfree86-nonfree
+ttf-xfree86-nonfree
+ttf-xfree86-nonfree-syriac

--- a/Ubuntu-files/20.04/apt_nice_to_have.txt
+++ b/Ubuntu-files/20.04/apt_nice_to_have.txt
@@ -1,0 +1,4 @@
+# APT Always nice to have packages
+tree
+manpages-dev    # man pages for C standard library
+mlocate         # Provides the locate command

--- a/Ubuntu-files/20.04/apt_optional_compile_R.txt
+++ b/Ubuntu-files/20.04/apt_optional_compile_R.txt
@@ -1,0 +1,10 @@
+# APT optional packages for compiling R
+gobjc
+libpng-dev
+libjpeg-dev
+libtiff-dev
+libcairo2-dev
+libicu-dev
+tcl-dev
+tk-dev
+default-jdk

--- a/Ubuntu-files/20.04/apt_required_build.txt
+++ b/Ubuntu-files/20.04/apt_required_build.txt
@@ -1,0 +1,4 @@
+# APT Packages required by the build system
+python3-minimal
+python3-pip
+git

--- a/Ubuntu-files/20.04/apt_required_compile_R.txt
+++ b/Ubuntu-files/20.04/apt_required_compile_R.txt
@@ -1,0 +1,11 @@
+# APT packages required to compile R
+build-essential
+gfortran
+libreadline-dev
+libx11-dev
+libxt-dev
+zlib1g-dev
+libbz2-dev
+liblzma-dev
+libpcre2-dev
+libcurl4-openssl-dev

--- a/Ubuntu-files/20.04/apt_vignettes_reference_manuals.txt
+++ b/Ubuntu-files/20.04/apt_vignettes_reference_manuals.txt
@@ -1,0 +1,16 @@
+# APT packages for building vignettes and reference manuals
+texlive
+texlive-font-utils          # for epstopdf
+texlive-pstricks            # provides pstricks.sty
+texlive-latex-extra         # provides fullpage.sty
+texlive-fonts-extra         # provides incosolata.sty
+texlive-bibtex-extra        # provides unsrturl.bst
+texlive-science             # provides algorithm.sty
+texlive-luatex              # provides luatex85.sty
+texlive-lang-european       # provides language definition files e.g. swedish.ldf
+texi2html
+texinfo
+pandoc                      # needed for CRAN package knitr
+pandoc-citeproc             # needed for CRAN package knitr
+biber
+#ttf-mscorefonts-installer

--- a/Ubuntu-files/20.04/pip_pkgs.txt
+++ b/Ubuntu-files/20.04/pip_pkgs.txt
@@ -1,0 +1,17 @@
+# PIP packages required by CRAN or Bioconductor packages
+numpy                       # BiocSklearn, MOFA, MOFA2, CChIPRep
+scipy                       # MOFA, MOFA2, Python sklearn package
+sklearn                     # BiocSklearn, MOFA, MOFA2
+h5py == 2.10.0              # BiocSklearn, MOFA, MOFA2
+pandas                      # BiocSklearn, MOFA, MOFA2
+mofapy                      # MOFA, MOFA2
+mofapy2                     # MOFA, MOFA2
+testresources
+tensorflow == 2.4.1         # scAlign, netReg, DeepPINCS
+tensorflow_probability      # netReg
+h5pyd                       # rhdf5client
+cwltool                     # Rcwl
+nbconvert                   # CRAN nbconvertR for BioC destiny
+jupyter                     # CRAN nbconvertR for BioC destiny 
+matplotlib                  # CRAN phateR for BioC phemd
+phate                       # CRAN phateR for BioC phemd

--- a/Ubuntu-files/20.04/pip_spb.txt
+++ b/Ubuntu-files/20.04/pip_spb.txt
@@ -1,0 +1,2 @@
+# PIP Packages required by the Single Package Builder
+virtualenv


### PR DESCRIPTION
In addition to the apt packages, I've also included the pip packages. I've added a comment for each package that had one in the documentation.

Since I created the files, I removed the package names from https://github.com/Bioconductor/BBS/blob/master/Doc/Prepare-Ubuntu-20.04-HOWTO.md and replaced them with links to the appropriate files. I provided instructions how to use the Ubuntu file with some code. Where there were long explanations for why a particular package is installed, I opted to leave it in. All short comments I put in Ubuntu-files. I'd appreciate any feedback to make this better.

Closes #83.