### PR TITLE
Remove cwltool dependency for Rcwl

### DIFF
--- a/Doc/Prepare-Ubuntu-20.04-HOWTO.md
+++ b/Doc/Prepare-Ubuntu-20.04-HOWTO.md
@@ -432,9 +432,6 @@ Note that a reboot is required to make the fix effective.
 
 For CRAN packages, install [apt_cran.txt](../Ubuntu-files/20.04/apt_cran.txt).
 
-Notes:
-- Do NOT install `cwltool` (for Rcwl)! Install with `pip3` instead (see below).
-
 For BioC packages, install [apt_bioc.txt](../Ubuntu-files/20.04/apt_bioc.txt).
 
 Notes:
@@ -501,8 +498,6 @@ Notes:
 - `tensorflow_probability` is needed by Bioconductor package netReg.
 
 - `h5pyd` is needed by Bioconductor package rhdf5client.
-
-- `cwltool` is needed by Bioconductor package Rcwl.
 
 - `nbconvert` and `jupyter` are needed by CRAN package nbconvertR which is
   itself used by Bioconductor package destiny. Note that `jupyter --version`

--- a/Ubuntu-files/20.04/pip_pkgs.txt
+++ b/Ubuntu-files/20.04/pip_pkgs.txt
@@ -10,7 +10,6 @@ testresources
 tensorflow == 2.4.1         # scAlign, netReg, DeepPINCS
 tensorflow_probability      # netReg
 h5pyd                       # rhdf5client
-cwltool                     # Rcwl
 nbconvert                   # CRAN nbconvertR for BioC destiny
 jupyter                     # CRAN nbconvertR for BioC destiny 
 matplotlib                  # CRAN phateR for BioC phemd


### PR DESCRIPTION
We no longer need `cwltool` for `Rcwl`. I tested in Bioconductor Docker by attempting to `R CMD Build` and `R CMD INSTALL`. What additional testing do we need?