### PR TITLE
Add instructions to install .NET runtime in Ubuntu

### DIFF
--- a/Doc/Prepare-Ubuntu-20.04-HOWTO.md
+++ b/Doc/Prepare-Ubuntu-20.04-HOWTO.md
@@ -1137,27 +1137,24 @@ For more about installing .NET, see https://docs.microsoft.com/en-us/dotnet/core
 
 #### Install the Microsoft signing key
 
-```
-wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-sudo dpkg -i packages-microsoft-prod.deb
-rm packages-microsoft-prod.deb
-```
+    wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+    sudo dpkg -i packages-microsoft-prod.deb
+    rm packages-microsoft-prod.deb
+
 
 #### Install the runtime
 
-```
-sudo apt-get update; \
-  sudo apt-get install -y apt-transport-https && \
-  sudo apt-get update && \
-  sudo apt-get install -y aspnetcore-runtime-5.0
-```
+    sudo apt-get update; \
+      sudo apt-get install -y apt-transport-https && \
+      sudo apt-get update && \
+      sudo apt-get install -y aspnetcore-runtime-5.0
+
 
 #### Test if rmspc installs as biocbuild
-```
-cd ~/bbs-3.14-bioc/meat/
-../R/bin/R CMD build rmspc
-../R/bin/R CMD check --no-vignettes rmspc_X.Y.Z.tar.gz
-```
+
+    cd ~/bbs-3.14-bioc/meat/
+    ../R/bin/R CMD build rmspc
+    ../R/bin/R CMD check --no-vignettes rmspc_X.Y.Z.tar.gz
 
 
 ### 3.8 Install ROOT

--- a/Doc/Prepare-Ubuntu-20.04-HOWTO.md
+++ b/Doc/Prepare-Ubuntu-20.04-HOWTO.md
@@ -1129,7 +1129,38 @@ From the biocbuild account:
     ../R/bin/R CMD build LowMACA
 
 
-### 3.7 Install ROOT
+### 3.7 Install .NET runtime
+
+Required by Bioconductor package rmspc.
+
+For more about installing .NET, see https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#2004-. 
+
+#### Install the Microsoft signing key
+
+```
+wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+```
+
+#### Install the runtime
+
+```
+sudo apt-get update; \
+  sudo apt-get install -y apt-transport-https && \
+  sudo apt-get update && \
+  sudo apt-get install -y aspnetcore-runtime-5.0
+```
+
+#### Test if rmspc installs as biocbuild
+```
+cd ~/bbs-3.14-bioc/meat/
+../R/bin/R CMD build rmspc
+../R/bin/R CMD check --no-vignettes rmspc_X.Y.Z.tar.gz
+```
+
+
+### 3.8 Install ROOT
 
 SEPT 2020: THIS SHOULD NO LONGER BE NEEDED! (xps was deprecated in BioC 3.12)
 


### PR DESCRIPTION
Maybe this depends on whether we accept rmspc, which is in review at https://github.com/Bioconductor/Contributions/issues/2178.

I didn't think this should be added to the Ubuntu files because you need to install the Microsoft signing key.