### PR TITLE
Add libarchive-dev apt package

### DIFF
--- a/Ubuntu-files/20.04/apt_cran.txt
+++ b/Ubuntu-files/20.04/apt_cran.txt
@@ -25,3 +25,4 @@ libprotobuf-dev         # for protolite
 protobuf-compiler       # for protolite
 libglpk-dev             # for glpkAPI and to compile igraph with GLPK support
 libhiredis-dev          # for redux
+libarchive-dev          # for archive, a dependency of AlpsNMR


### PR DESCRIPTION
The Bioconductor AlpsNMR package has as dependency the archive package.

The archive CRAN package has as system requirement the libarchive-dev debian package.

Closes #220



Related:
- #220
- https://github.com/Bioconductor/bioconductor_docker/pull/53

Thanks for your support