### PR TITLE
Add try-except propagation status fails

### DIFF
--- a/BBS-make-PROPAGATION_STATUS_DB.py
+++ b/BBS-make-PROPAGATION_STATUS_DB.py
@@ -12,10 +12,11 @@ import os
 import time
 import subprocess
 
+import bbs.notify
+
 import BBSutils
 import BBSvars
 import BBSbase
-import bbs.notify
 
 def make_PROPAGATION_STATUS_DB(final_repo):
     Rfunction = 'makePropagationStatusDb'
@@ -35,14 +36,16 @@ def make_PROPAGATION_STATUS_DB(final_repo):
         subprocess.run(cmd, stdout=None, stderr=subprocess.STDOUT, shell=True,
                        check=True)
     except subprocess.CalledProcessError as e:
+        subject = (f"[BBS] {BBSvars.bioc_version} {BBSvars.buildtype} Postrun "
+                   f"Failure")
         msg_body = f"""\
         Postrun failed on the BBS with the following error:
 
         Error: {e}"""
         bbs.notify.mode = "do-it"
-        bbs.notify.sendtextmail("no-reply@bioconductor.org",
+        bbs.notify.sendtextmail("BBS-noreply@bioconductor.org",
                                 ["maintainers@bioconductor.org"],
-                                "[BBS] PostRun Failed",
+                                subject,
                                 msg_body)
         raise e
     return

--- a/BBS-make-PROPAGATION_STATUS_DB.py
+++ b/BBS-make-PROPAGATION_STATUS_DB.py
@@ -36,10 +36,11 @@ def make_PROPAGATION_STATUS_DB(final_repo):
         subprocess.run(cmd, stdout=None, stderr=subprocess.STDOUT, shell=True,
                        check=True)
     except subprocess.CalledProcessError as e:
-        subject = (f"[BBS] {BBSvars.bioc_version} {BBSvars.buildtype} Postrun "
-                   f"Failure")
+        subject = (f"[BBS] Postrun failure on {BBSvars.node_hostname} for "
+                   f"{BBSvars.bioc_version} {BBSvars.buildtype} builds")
         msg_body = f"""\
-        Postrun failed on the BBS with the following error:
+        Postrun failed on {BBSvars.node_hostname} for the {BBSvars.bioc_version}
+        {BBSvars.buildtype} builds with the following error:
 
         Error: {e}"""
         bbs.notify.mode = "do-it"

--- a/BBS-make-PROPAGATION_STATUS_DB.py
+++ b/BBS-make-PROPAGATION_STATUS_DB.py
@@ -44,7 +44,7 @@ def make_PROPAGATION_STATUS_DB(final_repo):
         Error: {e}"""
         bbs.notify.mode = "do-it"
         bbs.notify.sendtextmail("BBS-noreply@bioconductor.org",
-                                ["maintainers@bioconductor.org"],
+                                ["maintainer@bioconductor.org"],
                                 subject,
                                 msg_body)
         raise e

--- a/BBS-make-PROPAGATION_STATUS_DB.py
+++ b/BBS-make-PROPAGATION_STATUS_DB.py
@@ -15,6 +15,7 @@ import subprocess
 import BBSutils
 import BBSvars
 import BBSbase
+import bbs.notify
 
 def make_PROPAGATION_STATUS_DB(final_repo):
     Rfunction = 'makePropagationStatusDb'
@@ -30,8 +31,20 @@ def make_PROPAGATION_STATUS_DB(final_repo):
     ## subprocess.run() if this code is runned by the Task Scheduler
     ## on Windows (the child process tends to almost always return an
     ## error). Apparently using 'stderr=subprocess.STDOUT' fixes this pb.
-    subprocess.run(cmd, stdout=None, stderr=subprocess.STDOUT, shell=True,
-                   check=True)
+    try:
+        subprocess.run(cmd, stdout=None, stderr=subprocess.STDOUT, shell=True,
+                       check=True)
+    except subprocess.CalledProcessError as e:
+        msg_body = f"""\
+        Postrun failed on the BBS with the following error:
+
+        Error: {e}"""
+        bbs.notify.mode = "do-it"
+        bbs.notify.sendtextmail("no-reply@bioconductor.org",
+                                ["maintainers@bioconductor.org"],
+                                "[BBS] PostRun Failed",
+                                msg_body)
+        raise e
     return
 
 ##############################################################################


### PR DESCRIPTION
I tested on jetstream by removing some files in `public_html/3.17/bioc/nebbiolo1/buildsrc` and the end of run file. It sends a message to maintainers from no-reply@bioconductor.org with the subject "[BBS] PostRun Failed" and the following content:

        Postrun failed on the BBS with the following error:
        Error: Command '/home/biocbuild/bbs-3.17-bioc/R/bin/Rscript -e "source('/home/biocbuild/BBS/utils/makePropagationStatusDb.R');makePropagationStatusDb('OUTGOING','file://home/biocpush/PACKAGES/3.17/bioc',db_filepath='PROPAGATION_STATUS_DB.txt')"' returned non-zero exit status 1.

Would it be possible to split this from the other scenario because this could be useful as the other might take a little time to understand?

Close #297

