### PR TITLE
Lower the values of BBS_**_CPU settings for kunpeng2

### DIFF
--- a/3.18/bioc/kunpeng2/config.sh
+++ b/3.18/bioc/kunpeng2/config.sh
@@ -12,9 +12,9 @@ export BBS_USER="biocbuild"
 export BBS_WORK_TOPDIR="/home/biocbuild/bbs-3.18-bioc"
 export BBS_R_HOME="/home/biocbuild/R/R-4.3.1"
 export R_LIBS="$BBS_R_HOME/site-library"
-export BBS_NB_CPU=28         # 32 cores are available
+export BBS_NB_CPU=25         # 32 cores are available
 export BBS_BUILD_NB_CPU=20   # 32 cores are available
-export BBS_CHECK_NB_CPU=25   # 32 cores are available
+export BBS_CHECK_NB_CPU=20   # 32 cores are available
 
 export BBS_PRODUCT_TRANSMISSION_MODE="none"
 

--- a/3.18/bioc/kunpeng2/config.sh
+++ b/3.18/bioc/kunpeng2/config.sh
@@ -13,7 +13,7 @@ export BBS_WORK_TOPDIR="/home/biocbuild/bbs-3.18-bioc"
 export BBS_R_HOME="/home/biocbuild/R/R-4.3.1"
 export R_LIBS="$BBS_R_HOME/site-library"
 export BBS_NB_CPU=25         # 32 cores are available
-export BBS_BUILD_NB_CPU=20   # 32 cores are available
+export BBS_BUILD_NB_CPU=16   # 32 cores are available
 export BBS_CHECK_NB_CPU=20   # 32 cores are available
 
 export BBS_PRODUCT_TRANSMISSION_MODE="none"


### PR DESCRIPTION
With the old ones the system is too busy and the builds and checks of some packages fail due to timeouts