### PR TITLE
Increase BBS_CHECK_NB_CPU from 20 to 22

### DIFF
--- a/3.18/bioc/kunpeng2/config.sh
+++ b/3.18/bioc/kunpeng2/config.sh
@@ -14,7 +14,7 @@ export BBS_R_HOME="/home/biocbuild/R/R-4.3.1"
 export R_LIBS="$BBS_R_HOME/site-library"
 export BBS_NB_CPU=25         # 32 cores are available
 export BBS_BUILD_NB_CPU=16   # 32 cores are available
-export BBS_CHECK_NB_CPU=20   # 32 cores are available
+export BBS_CHECK_NB_CPU=22   # 32 cores are available
 
 export BBS_PRODUCT_TRANSMISSION_MODE="none"
 


### PR DESCRIPTION
https://community-bioc.slack.com/archives/C04HZMP49LH/p1697688014369869

```
Hervé Pagès
  3 hours ago
@Martin Grigorov
 It seems that kunpeng2 can no longer finish the builds in time: https://bioconductor.org/checkResults/3.18/bioc-LATEST/kunpeng2-index.html See NAs in the CHECK column towards the end of the report.
Probably a consequence of decreasing  BBS_CHECK_NB_CPU from 25 to 20 https://github.com/Bioconductor/BBS/pull/341 Do you want to try to increase it to 22? (21 might not be enough). Unfortunately this might increase slightly the number of TIMEOUTs we see on the machine, which is already quite high.
```