### PR TITLE
kunpeng2: Use /home/biocbuild/R/R as BBS_R_HOME

### DIFF
--- a/3.20/bioc/kunpeng2/config.sh
+++ b/3.20/bioc/kunpeng2/config.sh
@@ -12,7 +12,7 @@ export BBS_DEBUG="0"
 export BBS_NODE_HOSTNAME="kunpeng2"
 export BBS_USER="biocbuild"
 export BBS_WORK_TOPDIR="/home/biocbuild/bbs-3.20-bioc"
-export BBS_R_HOME="/home/biocbuild/R/R-devel_2024-01-16_r85812"
+export BBS_R_HOME="/home/biocbuild/R/R"
 export R_LIBS="$BBS_R_HOME/site-library"
 
 # kunpeng2 has 32 logical CPUs.


### PR DESCRIPTION
```
biocbuild@kunpeng2 ~/BBS (devel)> ll ~/R
total 11M
-rw-r--r--  1 biocbuild biocbuild  128 Apr 18 06:21 download_urls.txt
lrwxrwxrwx  1 biocbuild biocbuild    7 May  9 12:35 R -> R-4.4.0
drwxr-xr-x 16 biocbuild biocbuild 4.0K May  9 12:36 R-4.4.0
```

This way I could just update the symlink on the system without sending a PR for each update of R.