### PR TITLE
Fix manuals path

### DIFF
--- a/BBS-make-OUTGOING.py
+++ b/BBS-make-OUTGOING.py
@@ -120,7 +120,7 @@ def copy_outgoing_pkgs(products_in_subdir, source_node):
             pass
         elif source_node:
             pdf_file = os.path.join(BBSvars.products_in_rdir,
-                                    BBSutils.getSourceNode(BBSvars.buildtype)?
+                                    BBSutils.getSourceNode(),
                                     '%s.Rcheck' % pkg,
                                     '%s-manual.pdf' % pkg)
             print('BBS> [stage6b]   - copying %s to OUTGOING/manuals folder...' % pdf_file)

--- a/BBS-make-OUTGOING.py
+++ b/BBS-make-OUTGOING.py
@@ -119,8 +119,9 @@ def copy_outgoing_pkgs(products_in_subdir, source_node):
         if BBSvars.buildtype in ['workflows', 'books', 'bioc-mac-arm64']:
             pass
         elif source_node:
-            pdf_file = os.path.join(BBSvars.products_in_rdir,
+            pdf_file = os.path.join(BBSvars.products_in_rdir.path,
                                     BBSutils.getSourceNode(),
+                                    'checksrc',
                                     '%s.Rcheck' % pkg,
                                     '%s-manual.pdf' % pkg)
             print('BBS> [stage6b]   - copying %s to OUTGOING/manuals folder...' % pdf_file)

--- a/BBS-make-OUTGOING.py
+++ b/BBS-make-OUTGOING.py
@@ -119,11 +119,11 @@ def copy_outgoing_pkgs(products_in_subdir, source_node):
         if BBSvars.buildtype in ['workflows', 'books', 'bioc-mac-arm64']:
             pass
         elif source_node:
-            pdf_file = os.path.join(BBSutils.getenv('BBS_WORK_TOPDIR'),
-                                    'meat',
+            pdf_file = os.path.join(BBSvars.products_in_rdir,
+                                    BBSutils.getSourceNode(BBSvars.buildtype)?
                                     '%s.Rcheck' % pkg,
                                     '%s-manual.pdf' % pkg)
-            print('BBS> [stage6b]   - copying %s manual to OUTGOING/manuals folder...' % pkg)
+            print('BBS> [stage6b]   - copying %s to OUTGOING/manuals folder...' % pdf_file)
             if os.path.exists(pdf_file):
                 dst = os.path.join(manuals_dir, '%s.pdf' % pkg)
                 #shutil.copy(pdf_file, dst)

--- a/BBSutils.py
+++ b/BBSutils.py
@@ -109,6 +109,14 @@ def getNodeSpec(node_hostname, key, key_is_optional=False):
         return specs.get(key)
     return specs[key]
 
+# Return Source node's name to construct a path
+def getSourceNode():
+    source_machines = []
+    for build in getenv('BBS_OUTGOING_MAP').split(" "):
+        if build.count("source"):
+            source_machines.append(build.strip("source:|/buildsrc)"))
+    return source_machines[0]
+
 
 ##############################################################################
 ### copyTheDamnedThingNoMatterWhat()


### PR DESCRIPTION
When the nebbiolos were the primary builders, manuals could be grabbed from the `meat` directories, which contained the `.Rcheck` directory for each package; however, on bbscentrals, `.Rcheck` directories don't exist in the `meat`. They should be copied from the `public_html` path for the build machine that we use for source packages (the x86_64 linux machines).